### PR TITLE
MCM updates

### DIFF
--- a/spec/Memory_Consistency.tex
+++ b/spec/Memory_Consistency.tex
@@ -8,6 +8,14 @@
   with, the broader community.
 \end{openissue}
 
+TODO -- reduce the number of hits to C++
+TODO 30.6 put open issues first
+TODO 30.3.1 --forall "The following text that refers to foralls also
+covers promotion", also separate tasks "for purposes of MCM" - whether
+separate in actuality depends ot the implementation of the parallel
+iterator (see parallel iterators chapter).
+TODO -- on mentioned too many times
+
 In this section, we describe Chapel's memory consistency model. This memory
 consistency model is in the spirit of Sequential Consistency (SC) for
 data-race-free programs adopted by C11, C++11, Java, UPC, and Fortran 2008. In
@@ -126,7 +134,9 @@ We will use the following notation:
   (see sections \ref{relating_to_C_MCM} and \ref{relaxed_atomics}). All
   atomic operations must be completed in a single step (i.e. atomically)
   and so it is not possible to observe an intermediate state from an
-  atomic operation under any circumstances.
+  atomic operation under any circumstances. TODO -- change notation to
+  A-r(a,o) for these relaxed operations and call A-sc, and don't let A-r
+  be sequentially consistent.
 
   \item $A(a)$ indicates an \textit{atomic operation} on a variable at
   address $a$ with sequential consistency ordering constraint. $a$ could
@@ -144,6 +154,7 @@ We will use the following notation:
   \item \chpl{wait($t_1$..$t_n$)} wait for tasks $t_1..t_n$ to complete
 
   \item \chpl{on(L)} run the remainder of this task on locale $L$
+   TODO: on has no impact on the program order, don't mention it again.
 
 \end{itemize}
 
@@ -187,13 +198,15 @@ operations} and we have $x_i <_p y_j$.
 Likewise, for the purposes of this memory model, Chapel's parallelism keywords
 are viewed as a sequence of operations including the primitives of starting a
 task (\chpl{begin}) and waiting for some number of tasks
-(\chpl{wait($t_1$..$t_n$)}). In particular:
+(\chpl{wait($t_1$..$t_n$)}). In particular: TODO promotion
 
 \begin{itemize}
 
   \item \chpl{forall} creates some implementation-dependent number of tasks $n$
 with \chpl{$t_i$ = begin\{some-loop-bodies\}} to execute some number of loop
 iterations and waits for them to complete with \chpl{wait($t_1$..$t_n$)}.
+TODO all iterations independent. Uses n tasks. (may not correspond to
+runtime task).
 
   \item \chpl{coforall} creates one task per loop iteration (\chpl{$t_i$ =
 begin\{loop-body\}} for all loop iterations $i=1..n$) and then waits for them
@@ -205,9 +218,12 @@ waits for them all to complete (with \chpl{wait($t_1$..$t_n$)}).
 
   \item \chpl{begin} creates a task to execute the contained statement and adds
 it to a list of tasks executing in dynamic scope (\chpl{t = begin\{X\}}).
+TODO -- include formal name for the task of lists.
 
   \item \chpl{sync} statement waits for all of the $n$ tasks $t_i$ created in
 the dynamic scope of the sync statement with \chpl{wait($t_1$..$t_n$)}.
+
+TODO -- promote sync/single bullet here and describe in terms of A.
 
 \end{itemize}
 

--- a/spec/Memory_Consistency.tex
+++ b/spec/Memory_Consistency.tex
@@ -2,57 +2,39 @@
 \label{Memory_Consistency_Model}
 \index{memory consistency model}
 
-\begin{openissue}
-  This chapter is a work-in-progress and represents an area where we
-  are particularly interested in feedback from, and collaboration
-  with, the broader community.
-\end{openissue}
+%% Michael's notes
+%% - TODO -- reduce the number of hits to C++
+%%   sungeun: done
+%%   
+%% - TODO 30.6 put open issues first
+%%   sungeun: done, but don't know if I like it
+%%   
+%% - TODO 30.3.1 --forall "The following text that refers to foralls also
+%% covers promotion", also separate tasks "for purposes of MCM" - whether
+%% separate in actuality depends ot the implementation of the parallel
+%% iterator (see parallel iterators chapter).
+%%   sungeun: see below
+%%
+%% - TODO -- on mentioned too many times
+%%   sungeun: done
+%%   
 
-TODO -- reduce the number of hits to C++
-TODO 30.6 put open issues first
-TODO 30.3.1 --forall "The following text that refers to foralls also
-covers promotion", also separate tasks "for purposes of MCM" - whether
-separate in actuality depends ot the implementation of the parallel
-iterator (see parallel iterators chapter).
-TODO -- on mentioned too many times
+In this section, we describe Chapel's memory consistency model. The
+model is based on \emph{sequential consistency for data-race-free}
+programs as adopted by C11, C++11, Java, UPC, and Fortran 2008.
 
-In this section, we describe Chapel's memory consistency model. This memory
-consistency model is in the spirit of Sequential Consistency (SC) for
-data-race-free programs adopted by C11, C++11, Java, UPC, and Fortran 2008. In
-particular, correct programs will use synchronization constructs when tasks
-communicate with each other. This model does not define the behavior of
-programs with
-data races. Furthermore, the implementation cannot be relied on to produce
-consistent behavior for such programs. In other words, programs with data
-races are not correct programs.
-
-The \chpl{forall}, \chpl{coforall}, \chpl{cobegin}, \chpl{begin}
-statements, as well as
-the \chpl{forall} expression and promoted functions or operators can
-create multiple tasks in a Chapel program. When two or more tasks operate on
-the same memory location concurrently, and at least one of the operations is a
-write, there will be a \textit{data race} unless the tasks are correctly
-synchronized.
-
-Chapel provides several ways to correctly synchronize tasks:
-
-\begin{itemize}
-
-  \item fork-join parallelism with Chapel's data parallel features such as
-  \chpl{forall} (see Chapter \ref{Data_Parallelism})
-
-  \item fork-join parallelism with \chpl{forall}, \chpl{coforall},
-  \chpl{cobegin}, or with \chpl{begin} and \chpl{sync} statements (see
-  Chapter \ref{Task_Parallelism_and_Synchronization})
-
-
-  \item shared variables safe for multiple tasks to access, including
-  \chpl{sync}, \chpl{single}, and \chpl{atomic} variables (see Chapter
-  \ref{Task_Parallelism_and_Synchronization})
-
-\end{itemize}
-
-\section{Design Principles}
+Sequential consistency (SC) means that all Chapel tasks agree on the
+interleaving of memory operations and this interleaving results in an
+order is consistent with the order of operations in the program source
+code.  \emph{Conflicting memory operations}, i.e., operations to the
+same location and one of which is a write, form a data race if they
+are from different Chapel tasks and can be executed concurrently.  Any
+Chapel program with a data race is not a valid program, and an
+implementation cannot be relied upon to produce consistent behavior.
+Valid Chapel programs will use synchronization constructs such
+as \emph{sync}, \emph{single}, or \emph{atomic} variables or
+higher-level constructs based on these to enforce ordering for
+conflicting memory operations.
 
 The following design principles were used in developing Chapel's memory
 consistency model:
@@ -60,7 +42,7 @@ consistency model:
 \begin{enumerate}
 
   \item Sequential programs have program order semantics.  Programs that
-  are totally sequential cannot have data races and should appear to
+  are completely sequential cannot have data races and should appear to
   execute as though each statement was executed one at a time and in the
   expected order.
 
@@ -70,8 +52,8 @@ consistency model:
   must appear to be completed to a parent task when the parent task joins
   with that task.
 
-  \item Mult-locale programs have the same memory consistency model as
-  single locale programs. The Chapel language seeks to allow a single
+  \item Multi-locale programs have the same memory consistency model as
+  single-locale programs. The Chapel language seeks to allow a single
   description of an algorithm to work with different data distributions.
   A result of this property is that an expression of a program must be
   correct whether it is working on local or distributed data.
@@ -84,39 +66,53 @@ consistency model:
 
 \end{enumerate}
 
-See \textit{A Primer on Memory Consistency and Cache Coherence} by Sorin,
-Daniel J. and Hill, Mark D. and Wood, David A. for more background information
-on memory consistency models. This section will proceed in a manner inspired by
+See \textit{A Primer on Memory Consistency and Cache Coherence} by
+Sorin, \emph{et~al.} for more background information on memory
+consistency models. This chapter will proceed in a manner inspired by
 the $XC$ memory model described there.
 
-\section{Overview of the Memory Consistency Model}
+%% sungeun: Commented out from the original
+%%
+%% The memory consistency model for Chapel is similar to the C11 and C++11
+%% memory consistency models, with some minor exceptions which are described
+%% in section \ref{relating_to_C_MCM}.
 
-The memory consistency model for Chapel is similar to the C11 and C++11
-memory consistency models, with some minor exceptions which are described
-in section \ref{relating_to_C_MCM}. Section \ref{SC_for_DRF} directly
-describes Sequential Consistency for Data-Race-Free programs as an
-alternative way of understanding the recommended subset of the C11 and
-C++11 memory consistency models. This description does not fully specify
-the behavior of atomics using non-SC ordering. While non-SC atomic
-operations are available in Chapel, they are intended for advanced users
-only.  Advanced users should refer to section \ref{relating_to_C_MCM} or
-section \ref{relaxed_atomics}. Section \ref{relating_to_C_MCM} describes
-how to use the C11 and C++11 specifications to understand the behavior of
-Chapel programs using non-SC atomic operations. Section
-\ref{relaxed_atomics} extends the memory model described below to include
-relaxed atomic operations.
+%% Section \ref{SC_for_DRF} directly describes sequential consistency for
+%% data-race-free programs as an alternative way of understanding the
+%% recommended subset of the C11 and C++11 memory consistency
+%% models.
+
+%% This description does not fully specify the behavior of atomics using
+%% non-SC ordering. While non-SC atomic operations are available in
+%% Chapel, they are intended for advanced users only.  Advanced users
+%% should refer to section \ref{relating_to_C_MCM} or
+%% section \ref{relaxed_atomics}. Section \ref{relating_to_C_MCM}
+%% describes how to use the C11 and C++11 specifications to understand
+%% the behavior of Chapel programs using non-SC atomic
+%% operations. Section
+%% \ref{relaxed_atomics} extends the memory model described below to include
+%% relaxed atomic operations.
+
+
 
 \section{Sequential Consistency for Data-Race-Free Programs}
 \label{SC_for_DRF}
 \index{memory consistency model!sequential consistency for data-race-free programs}
 
-The memory consistency model is described in terms of two orders:
-\textit{program order} and \textit{memory order}. The \textit{program order}
-$<_p$ is a partial order describing serial or fork-join parallelism
-dependencies between variable reads and writes. The \textit{memory order} $<_m$
-is a total order that describes the semantics of atomic operations with
-sequential consistency. Non-SC atomic operations do not create this total
-order.
+Sequential consistency for data-race-free programs is described in
+terms of two orders: \textit{program order} and \textit{memory
+order}. The \textit{program order} $<_p$ is a partial order describing
+serial or fork-join parallelism dependencies between variable reads
+and writes. The \textit{memory order} $<_m$ is a total order that
+describes the semantics of synchronizing memory operations
+(via \chpl{atomic}, \chpl{sync} or \chpl{single} variables) with
+sequential consistency. Non-SC atomic operations (described in
+Section~\ref{non_sc_atomics}) do not create this total order.
+
+Note that \chpl{sync/single} variables have memory consistency
+behavior equivalent to a sequence of SC operations on \chpl{atomic}
+variables.  Thus for the remainder of the chapter, we will primarily
+focus on operations on \chpl{atomic} variables.
 
 We will use the following notation:
 \begin{itemize}
@@ -127,34 +123,85 @@ We will use the following notation:
   \item $S(a)$ indicates a \textit{store} to a variable at address $a$.
   $a$ could refer to local or remote memory.
 
-  \item $A(a,o)$ indicates an \textit{atomic operation} on a variable at
-  address $a$ with ordering constraint $o$. $a$ could refer to local or
-  remote memory.  $o$ can be sequential consistency or a more relaxed
-  non-SC ordering.  Non-SC orderings include relaxed, acquire, and release
-  (see sections \ref{relating_to_C_MCM} and \ref{relaxed_atomics}). All
-  atomic operations must be completed in a single step (i.e. atomically)
-  and so it is not possible to observe an intermediate state from an
-  atomic operation under any circumstances. TODO -- change notation to
-  A-r(a,o) for these relaxed operations and call A-sc, and don't let A-r
-  be sequentially consistent.
+  \item $A_{sc}(a)$ indicates an \textit{atomic operation} on a variable
+  at address $a$ with sequential consistency. The variable at address
+  $a$ could refer to local or remote memory.  Atomic operations must
+  be completed as a single operation (i.e. atomically), and so it is
+  not possible to observe an intermediate state from an atomic
+  operation under any circumstances.
 
-  \item $A(a)$ indicates an \textit{atomic operation} on a variable at
-  address $a$ with sequential consistency ordering constraint. $a$ could
-  refer to local or remote memory.
+  \item $A_r(a,o)$ indicates an \textit{atomic operation} on a
+  variable at address $a$ with ordering constraint $o$, where $o$ can
+  be one of \emph{relaxed}, \emph{acquire}, or \emph{release} (see
+  Section~\ref{non_sc_atomics}).  As with $A_{sc}(a)$, relaxed atomic
+  operations must be completed as a single operation.
 
-  \item $L(a)$, $S(a)$, $A(a,o)$, and $A(a)$ are also called
+  \item $L(a)$, $S(a)$, $A_{sc}(a)$, and $A_r(a,o)$ are also called
+
   \textit{memory operations}
 
   \item $X <_p Y$ indicates that $X$ precedes $Y$ in program order
 
   \item $X <_m Y$ indicates that $X$ precedes $Y$ in memory order
 
-  \item \chpl{t = begin\{X\}} start a new task named $t$ to execute $X$
+  \item \chpl{t = begin\{X\}} starts a new task named $t$ to execute $X$
 
-  \item \chpl{wait($t_1$..$t_n$)} wait for tasks $t_1..t_n$ to complete
+  \item \chpl{waitFor($t_1$..$t_n$)} waits for tasks $t_1..t_n$ to complete
 
-  \item \chpl{on(L)} run the remainder of this task on locale $L$
-   TODO: on has no impact on the program order, don't mention it again.
+  \item \chpl{on(L)} migrates the running task to locale $L$. Note
+that while the \chpl{on} statement may change the locale on which the
+current task is running, it has no impact on the memory consistency
+requirements.
+
+\end{itemize}
+
+For the purposes of describing this memory model, it is assumed that Chapel
+programs will be translated into sequences of \textit{memory operations},
+\chpl{begin} statements, and \chpl{waitFor} statements. The translation of a
+Chapel program into a sequence of \textit{memory operations} must
+preserve sequential program semantics. That is, if we have a snippet
+of a Chapel program without task operations, such as \chpl{X; Y;}, the
+statements $X$ and $Y$ will be converted into a sequence
+of \textit{load}, \textit{store}, and \textit{atomic operations} in a
+manner that preserves the behavior of a serial portion of the
+program. That is, $X=x_1,x_2,...$ and $Y=y_1,y_2,...$ where $x_i$ and
+$y_j$ are each a sequence of \textit{load}, \textit{store},
+or \textit{atomic operations} and we have $x_i <_p y_j$.
+
+Likewise, for the purposes of this memory model, Chapel's parallelism
+keywords are viewed as a sequence of operations including the
+primitives of starting a task (\chpl{begin}) and waiting for some
+number of tasks (\chpl{waitFor($t_1$..$t_n$)}). In particular:
+
+\begin{itemize}
+
+  \item \chpl{forall} (including promotion) creates some number of
+tasks $m$ to execute the $n$ iterations of the loop (\chpl{$t_i$ =
+begin\{some-loop-bodies\}} for each task $i=1$..$m$) and waits for
+them to complete (\chpl{waitFor($t_1$..$t_m$)}).  The number of tasks $m$
+is defined by the implementation of the parallel iterator (See
+Section~\ref{Iterators} for details on iterators).
+%% sungeun: I don't think we need to define a forall here, i.e., say
+%% that every iteration must be independent
+%%
+%% Brad suggested dropping forall all together.  What do you think?
+%%
+
+  \item \chpl{coforall} creates one task per loop iteration
+(\chpl{$t_i$ = begin\{loop-body\}} for all loop iterations $i=1..n$)
+and then waits for them all to complete (\chpl{waitFor($t_1$..$t_n$)}).
+
+  \item \chpl{cobegin} creates one task per enclosed statement
+(\chpl{$t_i$ = begin\{$X_i$\}} for statements $X_1$..$X_n$) and then
+waits for them all to complete (\chpl{waitFor($t_1$..$t_n$)}).
+
+  \item \chpl{begin} creates a task to execute the enclosed statement
+(\chpl{t = begin\{X\}}).  The \chpl{sync} statement waits for all
+tasks $t_i$ created by a begin statement in the dynamic scope of the
+sync statement that are not within other, nested \chpl{sync}
+statements (\chpl{waitFor($t_1$..$t_n$)} for all $n$ such tasks).
+%% sungeun: This used to say that tasks were added to a list, but
+%% that's an implementation detail.
 
 \end{itemize}
 
@@ -162,107 +209,55 @@ We will use the following notation:
 \label{program_order}
 
 Task creation and task waiting create a conceptual tree of program
-statements. Thus, the body of the tasks, task creation, and task wait
-operations create a partial order $<_p$ on memory operations.  
-For the purposes of this section, the statements in the body of each
-Chapel task will be implemented in terms of \textit{load}, \textit{store}, and
-\textit{atomic operations}. The $on$ statement might change where the current
-task is running but it has no impact on the memory consistency requirements.
+statements.  The task bodies, task creation, and task wait operations
+create a partial order $<_p$ of program statements.  For the purposes
+of this section, the statements in the body of each Chapel task will
+be implemented in terms of \textit{load}, \textit{store}, and
+\textit{atomic operations}.
+
 \begin{itemize}
   \item If we have a program snippet without tasks, such as \chpl{X; Y;},
-  where $X$ and $Y$ are memory operations (i.e. one of $L(a)$, $S(a)$, or
-  $A(a,o)$), then $X <_p Y$.
+  where $X$ and $Y$ are memory operations, then $X <_p Y$.
 
   \item The program \chpl{X; begin\{Y\}; Z;} implies $X$ $<_p$ $Y$.
   However, there is no particular relationship between $Y$ and $Z$ in
   program order.
 
-  \item The program \chpl{t = begin\{Y\}; wait(t); Z;} implies $Y$ $<_p$ $Z$
+  \item The program \chpl{t = begin\{Y\}; waitFor(t); Z;} implies $Y$ $<_p$ $Z$
 
   \item $X$ $<_p$ $Y$ and $Y$ $<_p$ $Z$ imply $X$ $<_p$ $Z$
 
 \end{itemize}
 
-For the purposes of describing this memory model, it is assumed that Chapel
-programs will be translated into sequences of \textit{memory operations},
-\chpl{begin} statements, and \chpl{wait} statements. The translation of a
-Chapel program into a sequence of \textit{memory operations} must preserve
-sequential program semantics. That is, if we have a snippet of a Chapel program
-without task operations, such as \chpl{X; Y;}, the statements $X$ and $Y$ will
-be converted into a sequence of \textit{load}, \textit{store}, and
-\textit{atomic operations} in a manner that preserves the behavior of a serial
-portion of the program. Thus, $X=x_1,x_2,...$ and $Y=y_1,y_2,...$ where $x_i$ and
-$y_j$ are each a sequence of \textit{load}, \textit{store}, or \textit{atomic
-operations} and we have $x_i <_p y_j$.
 
-Likewise, for the purposes of this memory model, Chapel's parallelism keywords
-are viewed as a sequence of operations including the primitives of starting a
-task (\chpl{begin}) and waiting for some number of tasks
-(\chpl{wait($t_1$..$t_n$)}). In particular: TODO promotion
+\subsection{Memory Order}
+\label{memory_order}
+
+The memory order $<_m$ of SC atomic operations in a given task
+repsects program order as follows:
 
 \begin{itemize}
-
-  \item \chpl{forall} creates some implementation-dependent number of tasks $n$
-with \chpl{$t_i$ = begin\{some-loop-bodies\}} to execute some number of loop
-iterations and waits for them to complete with \chpl{wait($t_1$..$t_n$)}.
-TODO all iterations independent. Uses n tasks. (may not correspond to
-runtime task).
-
-  \item \chpl{coforall} creates one task per loop iteration (\chpl{$t_i$ =
-begin\{loop-body\}} for all loop iterations $i=1..n$) and then waits for them
-all to complete (with \chpl{wait($t_1$..$t_n$)}).
-
-  \item \chpl{cobegin} creates one task per contained statement (\chpl{$t_i$ =
-begin\{$X_i$\}} for all contained statements $X_i$ with $i=1..n$) and then
-waits for them all to complete (with \chpl{wait($t_1$..$t_n$)}).
-
-  \item \chpl{begin} creates a task to execute the contained statement and adds
-it to a list of tasks executing in dynamic scope (\chpl{t = begin\{X\}}).
-TODO -- include formal name for the task of lists.
-
-  \item \chpl{sync} statement waits for all of the $n$ tasks $t_i$ created in
-the dynamic scope of the sync statement with \chpl{wait($t_1$..$t_n$)}.
-
-TODO -- promote sync/single bullet here and describe in terms of A.
-
+  \item If $A_{sc}(a)<_pA_{sc}(b)$ then $A_{sc}(a)<_mA_{sc}(b)$
 \end{itemize}
 
-For the purposes of the memory model, the \chpl{on} statement does not have any
-special meaning for program order. Put another way, the \chpl{on} statement has
-sequential semantics and the memory consistency model is the same no matter
-where a task is executing.
-
-Also note that \chpl{sync/single} variables have memory consistency behavior
-equivalent to a sequence of SC operations on \chpl{atomic} variables and so are
-not separately described here. 
-
-\subsection{SC Atomics are Ordered}
-\label{sc_atomics_ordered}
-
-All tasks insert SC atomic operations into the order $<_m$ respecting
-program order as described in the rules below. Note that atomic operations with
-relaxed semantics (relaxed, acquire, or release semantics which are less strict
-than SC) do not create a total order for all memory locations.
-
+Every SC atomic operation gets its value from the last SC atomic
+operation before it to the same address in the total order $<_m$:
+%% sungeun: Brad didn't like max, but I couldn't think of anything better
 \begin{itemize}
-  \item If $A(a)<_pA(b)$ then $A(a)<_mA(b)$
+  \item Value of $A_{sc}(a)$ = Value of $max_{<_m} (
+  A_{sc}'(a)|A_{sc}'(a) <_m A_{sc}(a) ) $
 \end{itemize}
 
-\subsection{SC Atomic Store-Load Ordering}
-\label{sc_atomic_store_load}
-
-Every SC atomic operation gets its value from the last SC atomic operation before it to the same address in the total order $<_m$:
+For data-race-free programs, every load gets its value from the last
+store before it to the same address in the total order $<_m$:
 \begin{itemize}
-  \item Value of $A(a)$ = Value of $max_{<_m} ( A'(a)|A'(a) <_m A(a) ) $
+  \item Value of $L(a)$ = Value of $max_{<_m}$ $( S(a)|S(a)$ $<_m$ $L(a)$ or $S(a)$ $<_p$ $L(a) )$
 \end{itemize}
 
-\subsection{Loads and Stores are Ordered with SC Atomics}
-\label{loads_stores_ordererd_with_atomics}
-% was SC_for_DRF_atomic_order
-
-For data-race-free programs, all tasks insert loads and stores into the
-total order $<_m$ respecting the below rules which preserve the order of loads
-and stores relative to SC atomic operations.
+For data-race-free programs, loads and stores are ordered with SC
+atomics.  That is, loads and stores for a given task are in total
+order $<_m$ respecting the following rules which preserve the order of
+loads and stores relative to SC atomic operations:
 
 %Note that if a program contains data
 %races, the \textit{memory order} is not an order at all for the racy loads
@@ -271,20 +266,17 @@ and stores relative to SC atomic operations.
 %result in a value being written that is neither of the written values but is a
 %combination of the two writes).
 
-
 \begin{itemize}
-  \item If $L(a)<_pA(b)$ then $L(a)<_mA(b)$
-  \item If $S(a)<_pA(b)$ then $S(a)<_mA(b)$
-  \item If $A(a)<_pL(b)$ then $A(a)<_mL(b)$
-  \item If $A(a)<_pS(b)$ then $A(a)<_mS(b)$
+  \item If $L(a)<_pA_{sc}(b)$ then $L(a)<_mA_{sc}(b)$
+  \item If $S(a)<_pA_{sc}(b)$ then $S(a)<_mA_{sc}(b)$
+  \item If $A_{sc}(a)<_pL(b)$ then $A_{sc}(a)<_mL(b)$
+  \item If $A_{sc}(a)<_pS(b)$ then $A_{sc}(a)<_mS(b)$
 \end{itemize}
 
-\subsection{Loads and Stores Preserve Sequential Program Behavior}
-\label{loads_stores_program_order}
-
-For data-race-free programs, all tasks insert their loads and stores to the
-same address into the order $<_m$ respecting the following rules which preserve
-sequential program behavior:
+For data-race-free programs, loads and stores preserve sequential
+program behavior.  That is, loads and stores to the same address in a
+given task are in the order $<_m$ respecting the following rules which
+preserve sequential program behavior:
 
 \begin{itemize}
   \item If $L(a) <_p L'(a)$ then $L(a) <_m L'(a)$
@@ -292,13 +284,6 @@ sequential program behavior:
   \item If $S(a) <_p S'(a)$ then $S(a) <_m S'(a)$
 \end{itemize}
 
-\subsection{Store-Load Ordering}
-\label{store_load_program_order}
-
-For data-race-free programs, every load gets its value from the last store before it to the same address in the total order $<_m$:
-\begin{itemize}
-  \item Value of $L(a)$ = Value of $max_{<_m}$ $( S(a)|S(a)$ $<_m$ $L(a)$ or $S(a)$ $<_p$ $L(a) )$
-\end{itemize}
 
 % This table is commented out because I'm not totally sure it's correct.
 % Or at least it might be misleading. In particular, I don't feel that
@@ -329,9 +314,6 @@ For data-race-free programs, every load gets its value from the last store befor
 % \end{center}
 
 
-\todo{Don't count on data structures being safe for parallel update unless
-the data structure is designed to do so. Where in the spec should we say
-for example that you shouldn't do concurrent array appends?}
 % I don't think this belongs in the MCM section. I think it's valuable, but
 % inappropriate for it to be here in it's current form. I'm guessing this is
 % meant to lead into some of the discussions we had around optimizing data
@@ -385,197 +367,237 @@ for example that you shouldn't do concurrent array appends?}
 %
 %\end{itemize}
 
-\section{Relationship to the C11 and C++11 memory models}
-\label{relating_to_C_MCM}
-\index{memory consistency model!relationship to C memory consistency model}
+%% \section{Relationship to the C11 and C++11 memory models}
+%% \label{relating_to_C_MCM}
+%% \index{memory consistency model!relationship to C memory consistency model}
 
-We have already shown an outline of the memory consistency model for
-Chapel.  Some features of the language allow you to request an ordering
-more relaxed than SC ordering. This section describes how to understand
-Chapel programs in terms of the C11 and C++11 specifications. We will
-summarize some of the features of the C11 and C++11 memory models. These
-summaries should be taken only as an aid in understanding. Although we
-refer to the C++11 model specifically, the C11 memory model is extremely
-similar.
+%% We have already shown an outline of the memory consistency model for
+%% Chapel.  Some features of the language allow you to request an ordering
+%% more relaxed than SC ordering. This section describes how to understand
+%% Chapel programs in terms of the C11 and C++11 specifications. We will
+%% summarize some of the features of the C11 and C++11 memory models. These
+%% summaries should be taken only as an aid in understanding. Although we
+%% refer to the C++11 model specifically, the C11 memory model is extremely
+%% similar.
 
-\subsection{Understanding the C++11 memory model}
+%% \subsection{Understanding the C++11 memory model}
 
-The C++11 specification describes the memory consistency model in terms of
-a total order on atomic operations \textit{separately for each atomic
-memory location}. It does \textit{not} guarantee a global total order
-on atomic operations unless sequential consistency is always used. In
-particular, for relaxed consistency atomics, the operations on the atomics
-do complete in a total order \textit{for each atomic memory location}.  In
-other words, at any given moment, an atomic at address $a$ updated with a
-relaxed atomic operation by any number of threads will either have the
-result of the update or not. It cannot have an intermediate state.
-However, since it is a total order for each address, relaxed atomic
-operations to two different memory locations could be reordered.
+%% The C++11 specification describes the memory consistency model in terms of
+%% a total order on atomic operations \textit{separately for each atomic
+%% memory location}. It does \textit{not} guarantee a global total order
+%% on atomic operations unless sequential consistency is always used. In
+%% particular, for relaxed consistency atomics, the operations on the atomics
+%% do complete in a total order \textit{for each atomic memory location}.  In
+%% other words, at any given moment, an atomic at address $a$ updated with a
+%% relaxed atomic operation by any number of threads will either have the
+%% result of the update or not. It cannot have an intermediate state.
+%% However, since it is a total order for each address, relaxed atomic
+%% operations to two different memory locations could be reordered.
 
-The C++11 memory models also uses some key terms which we will summarize here:
+%% The C++11 memory models also uses some key terms which we will summarize here:
 
-\begin{itemize}
+%% \begin{itemize}
 
-  \item \textit{thread} an execution context for a stream of instructions.
+%%   \item \textit{thread} an execution context for a stream of instructions.
 
-  \item \textit{acquire semantics} means that no memory operation can move
-  from after the acquire operation to before the acquire operation.  Only
-  loads or atomic operations that read from memory can have
-  \textit{acquire semantics}.  For example, a load after an acquire
-  operation cannot return a value cached from before the acquire
-  operation.
+%%   \item \textit{acquire semantics} means that no memory operation can move
+%%   from after the acquire operation to before the acquire operation.  Only
+%%   loads or atomic operations that read from memory can have
+%%   \textit{acquire semantics}.  For example, a load after an acquire
+%%   operation cannot return a value cached from before the acquire
+%%   operation.
 
-  \item \textit{release semantics} means that no memory operation can move
-  from before the release operation to after the release operation.  Only
-  stores or atomic operations that write to memory can have
-  \textit{release semantics}.  For example, a store started before a
-  release operation must complete before the release operation completes.
+%%   \item \textit{release semantics} means that no memory operation can move
+%%   from before the release operation to after the release operation.  Only
+%%   stores or atomic operations that write to memory can have
+%%   \textit{release semantics}.  For example, a store started before a
+%%   release operation must complete before the release operation completes.
 
-  \item \textit{synchronizes with} expresses how threaded programs need
-  memory operations to be ordered. A \textit{release} operation to a particular
-  memory location M \textit{synchronizes with} an \textit{acquire} operation
-  that takes its value from the \textit{release} operation. In addition, thread
-  creation operation synchronizes with the new thread; and the thread
-  completion synchronizes with the joining operation in the parent thread.
+%%   \item \textit{synchronizes with} expresses how threaded programs need
+%%   memory operations to be ordered. A \textit{release} operation to a particular
+%%   memory location M \textit{synchronizes with} an \textit{acquire} operation
+%%   that takes its value from the \textit{release} operation. In addition, thread
+%%   creation operation synchronizes with the new thread; and the thread
+%%   completion synchronizes with the joining operation in the parent thread.
 
-  \item \textit{sequenced before} is a relationship indicating which operations
-  must always occur before other operations within the same thread in order to
-  preserve sequential program semantics.
+%%   \item \textit{sequenced before} is a relationship indicating which operations
+%%   must always occur before other operations within the same thread in order to
+%%   preserve sequential program semantics.
 
-  \item \textit{happens before} is a relationship indicating which operations
-  must always occur before other operations according to the memory consistency
-  model. \textit{happens before} includes the ordering required by
-  \textit{synchronizes with} as well as the ordering required by
-  \textit{sequenced before}.
+%%   \item \textit{happens before} is a relationship indicating which operations
+%%   must always occur before other operations according to the memory consistency
+%%   model. \textit{happens before} includes the ordering required by
+%%   \textit{synchronizes with} as well as the ordering required by
+%%   \textit{sequenced before}.
 
-\end{itemize}
+%% \end{itemize}
  
-The C++11 specifications provides the following memory orders that can be used to request particular memory consistency
-for each atomic operation. These memory orders are also available in
-Chapel.
-% C standard section 5.1.2.4 p 20, 7.17.3 and 7.17.4 p 277. C++ standard section 1.10 p11 and and 29 p 1113
-\begin{itemize}
-  \item \chpl{memory\_order\_relaxed} For an atomic operation, the value of the
-  atomic variable itself will be updated in a single operation, but the order
-  of other loads and stores or the order of relaxed atomic operations to other
-  addresses is not necessarily preserved.
+%% The C++11 specifications provides the following memory orders that can be used to request particular memory consistency
+%% for each atomic operation. These memory orders are also available in
+%% Chapel.
+%% % C standard section 5.1.2.4 p 20, 7.17.3 and 7.17.4 p 277. C++ standard section 1.10 p11 and and 29 p 1113
+%% \begin{itemize}
+%%   \item \chpl{memory\_order\_relaxed} For an atomic operation, the value of the
+%%   atomic variable itself will be updated in a single operation, but the order
+%%   of other loads and stores or the order of relaxed atomic operations to other
+%%   addresses is not necessarily preserved.
 
-  \item \chpl{memory\_order\_acquire} a load or read-modify-write operation has \textit{acquire
-  semantics}.
+%%   \item \chpl{memory\_order\_acquire} a load or read-modify-write operation has \textit{acquire
+%%   semantics}.
 
-  \item \chpl{memory\_order\_release} a store or read-modify-write operation has \textit{release
-  semantics}.
+%%   \item \chpl{memory\_order\_release} a store or read-modify-write operation has \textit{release
+%%   semantics}.
 
-  \item \chpl{memory\_order\_acq\_rel} a store operation has \textit{release
-  semantics} and a load operation has \textit{acquire semantics}.
+%%   \item \chpl{memory\_order\_acq\_rel} a store operation has \textit{release
+%%   semantics} and a load operation has \textit{acquire semantics}.
 
-  \item \chpl{memory\_order\_seq\_cst} Includes the properties of both
-  \chpl{memory\_order\_acquire} and \chpl{memory\_order\_release} and
-  additionally requires that there be a total ordering on
-  memory\_order\_seq\_cst operations. This is the default and corresponds
-  to SC ordering in section \ref{SC_for_DRF} above.
+%%   \item \chpl{memory\_order\_seq\_cst} Includes the properties of both
+%%   \chpl{memory\_order\_acquire} and \chpl{memory\_order\_release} and
+%%   additionally requires that there be a total ordering on
+%%   memory\_order\_seq\_cst operations. This is the default and corresponds
+%%   to SC ordering in section \ref{SC_for_DRF} above.
 
-\end{itemize}
+%% \end{itemize}
 
-\subsection{Mapping Chapel concepts to the C++11 memory model}
+%% \subsection{Mapping Chapel concepts to the C++11 memory model}
+%% sungeun: this subsection moved to the next section editted but
+%% comment out for use elsewhere
+%%
 
-The Chapel memory model is a generalization of the C++ memory model to
-distributed memory. To understand the semantics of programs using non-SC
-atomics, it is necessary to refer to the C++ memory model. Chapel programs
-will follow the C++ memory model with the following constraints:
-\begin{itemize}
-  \item a \textit{task} in Chapel corresponds to a \textit{thread} in C++
-  for the purposes of the memory model
+%% To understand the semantics of programs using non-SC atomics, it is
+%% necessary to refer to the C11/C++11 memory model. Chapel programs will
+%% follow the C11/C++11 memory model with the following additional :
+%% \begin{itemize}
+%%   \item a \textit{task} in Chapel corresponds to a \textit{thread} in C++
+%%   for the purposes of the memory model.
 
-  \item Chapel's parallel language features correspond to some combination of
-  thread creation and thread joining in the C++11 memory model. In particular,
-  the language features are described above in terms of \chpl{begin} and
-  \chpl{wait}. \chpl{begin} corresponds to thread creation and \chpl{wait}
-  corresponds to thread joining.
+%%   \item Chapel's parallel language features map to thread creation and
+%%   thread joining in the C++11 memory model. In particular, the
+%%   language features are described above in terms of \chpl{begin}
+%%   and \chpl{waitFor}. \chpl{begin} corresponds to thread creation
+%%   and \chpl{waitFor} corresponds to thread joining.
 
-\begin{openissue}
-  We do not intend to prevent optimizations that preserve a Chapel
-  program's behavior simply because theh Chapel program uses tasks.
-  For example, it should be possible to optimize the following program
-  to one that sets A = 1 and B = 2 without ever creating a task. The
-  above description might prevent such optimization.
+%% \begin{openissue}
+%%   We do not intend to prevent optimizations that preserve a Chapel
+%%   program's behavior simply because the Chapel program uses tasks.
+%%   For example, it should be possible to optimize the following program
+%%   to one that sets A = 1 and B = 2 without ever creating a task. The
+%%   above description might prevent such optimization.
 
-\begin{chapel}
-var A = 1;
-var B = 0;
-cobegin with (ref B) {
-  B = 2;
-}
-\end{chapel}
+%% \begin{chapel}
+%% var A = 1;
+%% var B = 0;
+%% cobegin with (ref B) {
+%%   B = 2;
+%% }
+%% \end{chapel}
 
-\end{openissue}
+%% \end{openissue}
 
-  \item Chapel's \chpl{sync} variables are equivalent to locks in the
-  C++11 memory model.
+%%   \item Chapel's \chpl{sync} variables are equivalent to locks in the
+%%   C++11 memory model.
 
-  \item The idea of \textit{program order} described above replaces the
-  C++11 notion of\textit{sequenced before}.
+%%   \item The idea of \textit{program order} described above replaces the
+%%   C++11 notion of \textit{sequenced before}.
 
-  \item the \chpl{on} statement has no effect on memory consistency.
+%%   \item Whether data is local or remote has no effect on memory consistency.
 
-  \item whether data is local or remote has no effect on memory consistency.
+%% \end{itemize}
 
-\end{itemize}
 
-\section{Relaxed Atomic Operations}
+\section{Non-Sequentially Consistent Atomic Operations}
+\label{non_sc_atomics}
+\index{memory consistency model!non-sequentially consisten atomic operations}
+
+Sequential consistency for atomic operations can be a performance
+bottleneck under some circumstances.  Chapel provides non-SC atomic
+operations to help alleviate such situations.  Such uses of atomic
+operations must be done with care and should generally not be used to
+synchronize tasks.
+
+Non-SC atomic operations are specified by providing a \emph{memory
+order} argument to the atomic operations.  See
+Section~\ref{Functions_on_Atomic_Variables} for more information on
+the memory order types.
+
+\subsection{Relaxed Atomic Operations}
 \label{relaxed_atomics}
+%% sungeun: As per Brad's suggestion let's move this text to a ``best
+%% practices'' document or something like that.
+%%
+%% The least error prone ways to use \chpl{memory\_order\_relaxed} is for
+%% variables that need atomic updates but that are not used to synchronize
+%% tasks. An example would be a running total computed by multiple tasks.
 
-Sequential consistency for atomic operations can be slow in some
-circumstances. As a result, a programmer might be tempted to use relaxed
-atomic operations by specifying the order \chpl{memory\_order\_relaxed}.
-Such uses of atomic operations must be done with care and should generally
-not be used to synchronize tasks.
+%% It is just as unreasonable to synchronize tasks with a non-atomic variable
+%% as it is to synchronize them with a \chpl{memory\_order\_relaxed} atomic
+%% variable. Both of these are disasterous for program correctness and should
+%% be avoided. Note that advanced users can combine
+%% \chpl{memory\_order\_relaxed} with fences to synchronize tasks.
 
-The least error prone ways to use \chpl{memory\_order\_relaxed} is for
-variables that need atomic updates but that are not used to synchronize
-tasks. An example would be a running total computed by multiple tasks.
-
-It is just as unreasonable to synchronize tasks with a non-atomic variable
-as it is to synchronize them with a \chpl{memory\_order\_relaxed} atomic
-variable. Both of these are disasterous for program correctness and should
-be avoided. Note that advanced users can combine
-\chpl{memory\_order\_relaxed} with fences to synchronize tasks.
-
-Although relaxed atomics do not complete in a total order by themselves,
-and might contribute to non-deterministic programs, relaxed atomics cannot
-contribute to a \textit{data race} that would prevent \textit{sequential
-consistency}.
+Although Chapel's relaxed atomic operations
+(\chpl{memory\_order\_relaxed}) do not complete in a total order by
+themselves and might contribute to non-deterministic programs, relaxed
+atomic operations cannot contribute to a data race that would prevent
+sequential consistency.
 
 When relaxed atomics are used only for atomicity and not as part of
 synchronizing tasks, their effect can be understood in the memory
 consistency model described in \ref{SC_for_DRF} by treating them as
-ordinary loads or stores - with two exceptions:
+ordinary loads or stores with two exceptions:
 
 \begin{itemize}
 
-\item atomic operations (including relaxed atomic operations) cannot
-create a \textit{data races}
+\item Atomic operations (including relaxed atomic operations) cannot
+create a data races.
 
-\item all atomic operations (including relaxed atomic operations) should
+\item All atomic operations (including relaxed atomic operations) should
 eventually be visible to all other threads. This property is not true for
-normal loads and stores. This property corresponds to paragraph 25 in the
-C++ specification section 1.10.
+normal loads and stores.
+%% sungeun: for our own reference
+%% This property corresponds to paragraph 25 in the
+%% C++ specification section 1.10.
 
 \end{itemize}
 
-\section{Unordered Loads and Stores}
-\todo{Greg/Sung should review this section more thoroughly.}
-The Chapel memory model also supports the idea of \textit{unordered} loads
-and stores.
+\section{Unordered Memory Operations}
+\label{unordered_operations}
+\index{memory consistency model!unordered memory operations}
 
-Instead of doing normal loads and stores to read or write local or remote
-memory, a Chapel program can use \textit{unordered} loads and stores when
-preserving sequential program behavior is not important. Let's use this
-notation:
+%% sungeun: Addressing Brad's comment, this isn't a syntax section, so
+%% no need to put it here.  Maybe?
+%%
+%% \begin{openissue}
+%% Syntax for \textit{unordered} operations has not yet been finalized.
+%% \end{openissue}
+
+\begin{openissue}
+Should Chapel provide a memory fence that only complete unordered
+operations started by the current task?
+\end{openissue}
+\begin{openissue}
+Should unordered operations on a particular memory address always wait
+for the address to be computed?
+\end{openissue}
+\begin{openissue}
+Does starting a task or joining with a task necessarily wait for
+unordered operations to complete?
+%% sungeun: commenting out for our own notes.
+%%
+%% (It would appear so from the current
+%% description and the C++11 semantics where thread creation and joining
+%% create a \textit{synchronizes with} relationship).
+\end{openissue}
+
+Rather than issuing normal loads and stores to read or write local or
+remote memory, a Chapel program can use \textit{unordered} loads and
+stores when preserving sequential program behavior is not
+important.  The following notation for unordered memory operations
+will be used in this section:
 
 \begin{itemize}
 
-  \item $UL(a)$ indicates an \textit{unorderd} \textit{load} from a
+  \item $UL(a)$ indicates an \textit{unordered} \textit{load} from a
   variable at address $a$. $a$ could point to local or remote memory.
 
   \item $US(a)$ indicates an \textit{unordered} \textit{store} to a
@@ -584,38 +606,33 @@ notation:
 
 \end{itemize}
 
-\subsection{\textit{unordered} Loads and Stores are ordered with SC Atomics}
-
-The \textit{unordered} loads and stores $UL(a)$ and $US(a)$ respect fences
-but not program order. The rule in section
-\ref{loads_stores_ordererd_with_atomics} is extended to \textit{unordered}
-operations:
+The \textit{unordered} loads and stores $UL(a)$ and $US(a)$ respect
+fences but not program order. As in Section~\ref{memory_order},
+Unordered loads and stores are ordered with SC atomics.  That is,
+unordered loads and stores for a given task are in total order $<_m$
+respecting the following rules which preserve the order of unordered
+loads and stores relative to SC atomic operations:
 
 \begin{itemize}
-  \item If $UL(a)<_pA(b)$ then $UL(a)<_mA(b)$
-  \item If $US(a)<_pA(b)$ then $US(a)<_mA(b)$
-  \item If $A(a)<_pUL(b)$ then $A(a)<_mUL(b)$
-  \item If $A(a)<_pUS(b)$ then $A(a)<_mUS(b)$
+  \item If $UL(a)<_pA_{sc}(b)$ then $UL(a)<_mA_{sc}(b)$
+  \item If $US(a)<_pA_{sc}(b)$ then $US(a)<_mA_{sc}(b)$
+  \item If $A_{sc}(a)<_pUL(b)$ then $A_{sc}(a)<_mUL(b)$
+  \item If $A_{sc}(a)<_pUS(b)$ then $A_{sc}(a)<_mUS(b)$
 \end{itemize}
 
-\subsection{\textit{unordered} Loads and Stores do not Preserve Sequential
-Program Behavior}
+Unordered loads and stores do not preserve sequential program behavior.
 
-The rules in sections \ref{loads_stores_program_order} and
-\ref{store_load_program_order} do not apply to \textit{unordered} loads
-and stores.
+\subsection{Unordered Memory Operations Examples}
 
-\subsection{\textit{unordered} Operations Examples}
+Unordered operations should be thought of as happening in a way that
+overlaps with the program task. Unordered operations started in
+different program statements can happen at the same time unless an SC
+atomic operation orders them.
 
-\textit{unordered} operations should be thought of as happening in a way that
-is overlapped with the program task. \textit{unordered} operations started in
-different program statements can happen at the same time unless an SC atomic
-operation orders them.
-
-Since \textit{unordered} operations started by a single task can happen at
-the same time, totally sequential programs can have a \textit{data race}
-when using \textit{unordered} operations. This follows from our original
-definition of \textit{data race}.
+Since unordered operations started by a single task can happen at the
+same time, totally sequential programs can have a data race when using
+unordered operations. This follows from our original definition of
+data race.
 
 \begin{chapel}
 var x: int;
@@ -625,19 +642,19 @@ writeln(x);
 \end{chapel}
 
 The value of \textit{x} at the end of this program could be 10 or 20. As a
-result, programs using \textit{unordered} loads and stores are not sequentially
-consistent unless the program can guarantee that \textit{unordered} operations
+result, programs using unordered loads and stores are not sequentially
+consistent unless the program can guarantee that unordered operations
 can never operate on the same memory at the same time when one of them is a
 store. In particular, the following are safe:
 
 \begin{itemize}
-  \item \textit{unordered} stores to disjoint regions of memory
-  \item \textit{unordered} loads from possibly overlapping regions of memory when no store could overlap with the loads
-  \item \textit{unordered} loads and stores to the same memory location
+  \item Unordered stores to disjoint regions of memory.
+  \item Unordered loads from potentially overlapping regions of memory when no store could overlap with the loads.
+  \item Unordered loads and stores to the same memory location
   when these are always separated by an atomic operation.
 \end{itemize}
 
-\textit{unordered} loads and stores are available as a performance
+Unordered loads and stores are available as a performance
 optimization. For example, a program computing a permutation on an array might
 want to move data between two arrays without requiring any ordering:
 
@@ -655,91 +672,79 @@ for i in 1..n {
 }
 \end{chapel}
 
-\begin{openissue}
-  We have not finalized syntax for \textit{unordered} operations.
-\end{openissue}
-\begin{openissue}
-  Should there be memory fences that only complete \textit{unordered} operations started by the current task?
-\end{openissue}
-\begin{openissue}
-  Should \textit{unordered} operations on a particular address always wait for the address to be computed?
-\end{openissue}
-\begin{openissue}
-  Does starting a task or joining with a task necessarily wait for unordered
-  operations to complete? (It would appear so from the current description
-  and the C++11 semantics where thread creation and joining create a
-  \textit{synchronizes with} relationship).
-\end{openissue}
 
-\section{Discussion}
+%%
+%% sungeun: Commnented out for now.
+%%
+%% \section{Discussion}
 
-\todo{We may or may not want to include this discussion section in the
-spec. Michael thinks that the reasoning here is worth understanding and
-recording somewhere.}
-Chapel's memory model does not include the \textit{write atomicity} or
-\textit{store atomicity} property for general variable writes for two reasons.
-First, an RDMA message could be partway through copying some data when another
-thread reads that data. Second, two portions of the machine could have some
-local hardware caches that complete writes for other cores at different times
-from further away cores as allowed by the C11 or C++11 memory models. Sorin,
-Hill and Wood define \textit{write atomicity} as the property that a store
-operation is logically seen by all other cores at once (section 5.5.2). This
-property is upheld for SC operations on \chpl{atomic} variables by
-construction (since these are in a total order). However, \textit{write
-atomicity} is not upheld for all atomic operations. For a given moment in any
-task's execution, a write to any \chpl{atomic} variable write is either
-entirely completed or entirely not yet started. This property is guaranteed for
-any \chpl{atomic} variables with any ordering constraint including relaxed.
-However, the property that a given write is seen by all other tasks at once is
-not upheld for atomic operations unless the SC ordering is used.
+%% \todo{We may or may not want to include this discussion section in the
+%% spec. Michael thinks that the reasoning here is worth understanding and
+%% recording somewhere.}
+%% Chapel's memory model does not include the \textit{write atomicity} or
+%% \textit{store atomicity} property for general variable writes for two reasons.
+%% First, an RDMA message could be partway through copying some data when another
+%% thread reads that data. Second, two portions of the machine could have some
+%% local hardware caches that complete writes for other cores at different times
+%% from further away cores as allowed by the C11 or C++11 memory models. Sorin,
+%% Hill and Wood define \textit{write atomicity} as the property that a store
+%% operation is logically seen by all other cores at once (section 5.5.2). This
+%% property is upheld for SC operations on \chpl{atomic} variables by
+%% construction (since these are in a total order). However, \textit{write
+%% atomicity} is not upheld for all atomic operations. For a given moment in any
+%% task's execution, a write to any \chpl{atomic} variable write is either
+%% entirely completed or entirely not yet started. This property is guaranteed for
+%% any \chpl{atomic} variables with any ordering constraint including relaxed.
+%% However, the property that a given write is seen by all other tasks at once is
+%% not upheld for atomic operations unless the SC ordering is used.
 
-For a distributed memory system, the straightforward implementation of SC
-atomics or sync variables will be sequentially consistent. The straightforward
-implementation is to follow these rules:
+%% For a distributed memory system, the straightforward implementation of SC
+%% atomics or sync variables will be sequentially consistent. The straightforward
+%% implementation is to follow these rules:
 
-\begin{itemize}
+%% \begin{itemize}
 
- \item every task issues these SC atomic operations in program order
+%%  \item every task issues these SC atomic operations in program order
 
- \item each SC atomic operation is performed at the home locale of the
- atomic variable in question (e.g. with an Active Message or with network
- hardware support)
+%%  \item each SC atomic operation is performed at the home locale of the
+%%  atomic variable in question (e.g. with an Active Message or with network
+%%  hardware support)
 
- \item each task does not start another operation until the SC atomic operation
- it is working on has completed.
+%%  \item each task does not start another operation until the SC atomic operation
+%%  it is working on has completed.
 
-\end{itemize}
+%% \end{itemize}
 
-In that case, the reasoning in Adve Hill "Implementing Sequential Consistency
-in Cache-Based Systems" applies and the executions of these synchronization
-operations will be sequentially consistent.
+%% In that case, the reasoning in Adve Hill "Implementing Sequential Consistency
+%% in Cache-Based Systems" applies and the executions of these synchronization
+%% operations will be sequentially consistent.
 
-If the SC atomic operations themselves are sequentially consistent and the
-program is free of data races, the load and store operations will also be
-sequentially consistent. The reasoning here is that:
+%% If the SC atomic operations themselves are sequentially consistent and the
+%% program is free of data races, the load and store operations will also be
+%% sequentially consistent. The reasoning here is that:
 
-\begin{itemize}
+%% \begin{itemize}
 
- \item The load and store operations cannot be reordered across SC atomic
- operations (see \ref{loads_stores_ordererd_with_atomics}).
+%%  \item The load and store operations cannot be reordered across SC atomic
+%%  operations (see \ref{loads_stores_ordererd_with_atomics}).
 
- \item Concurrent access by at least two tasks to the same memory location,
- when at least one of the accesses is a store, is a race condition. In order to
- avoid race conditions and preserve SC semantics, accesses to the same memory
- location from different tasks when one of the accesses is a store must be
- mediated by SC atomic operations.
+%%  \item Concurrent access by at least two tasks to the same memory location,
+%%  when at least one of the accesses is a store, is a race condition. In order to
+%%  avoid race conditions and preserve SC semantics, accesses to the same memory
+%%  location from different tasks when one of the accesses is a store must be
+%%  mediated by SC atomic operations.
 
- \item The SC atomic operation constrains the order of the load and store
- operations so that they appear as a total order.
-\end{itemize}
+%%  \item The SC atomic operation constrains the order of the load and store
+%%  operations so that they appear as a total order.
+%% \end{itemize}
 
-Sketch of proof. Suppose that a data-race-free program produces a non-SC
-outcome. That would mean that there is no total ordering on the loads or stores
-to a particular memory location. If the memory location is never updated in the
-relevant program region, the loads could be considered to be in any order in
-the total order and provide the same result. If at least one of the operations
-is a store, and it is not already constrained by the SC atomic operations, then
-there is a race condition.
+%% Sketch of proof. Suppose that a data-race-free program produces a non-SC
+%% outcome. That would mean that there is no total ordering on the loads or stores
+%% to a particular memory location. If the memory location is never updated in the
+%% relevant program region, the loads could be considered to be in any order in
+%% the total order and provide the same result. If at least one of the operations
+%% is a store, and it is not already constrained by the SC atomic operations, then
+%% there is a race condition.
 
 %(Corrolary 1: LLVM optimizations and C program optimizations are OK because C programs cannot reorder SC atomic ops)
 %(Corralary 2: Cache is OK because:
@@ -762,6 +767,8 @@ there is a race condition.
 %\url{http://www.cs.berkeley.edu/~kubitron/cs252/lectures/lec20-sharedmemory3.pdf} has a picture of "exclusion zone" and argument for why processor atomics -> sequential consistency.
 
 \section{Examples}
+\label{MCM_examples}
+\index{memory consistency model!examples}
 %\begin{chapelexample}{syncFenceFlag}
 \begin{example}
   In this example, a synchronization variable is used to (a) ensure that

--- a/spec/Task_Parallelism_and_Synchronization.tex
+++ b/spec/Task_Parallelism_and_Synchronization.tex
@@ -484,7 +484,6 @@ used to specify the ordering constraints of atomic operations. The
 supported memory\_order values are:
 \begin{itemize}
 \item{memory\_order\_relaxed}
-\item{memory\_order\_consume}
 \item{memory\_order\_acquire}
 \item{memory\_order\_release}
 \item{memory\_order\_acq\_rel}


### PR DESCRIPTION
- Updates from deep dive feedback
- remove memory_order_consume

NOTE: The diff is a mess, because I moved things around, reflowed text, etc.  I would read the chapter as a whole (it's a lot shorter now!) and review that.

I put my response or rationale in the .tex in comments (search for sungeun).  I got through almost all of Brad's comments, except dealing with the examples section.  It was suggested to possibly move that forward, but I couldn't quite figure out how to do it.

@mppf @ronawho @gbtitus
